### PR TITLE
Fix notification button hiding

### DIFF
--- a/jest.setup.js
+++ b/jest.setup.js
@@ -30,6 +30,7 @@ Object.defineProperty(window, "Notification", {
     requestPermission: jest.fn().mockResolvedValue("granted"),
   },
   writable: true,
+  configurable: true,
 });
 
 Object.defineProperty(navigator, "serviceWorker", {
@@ -47,6 +48,7 @@ Object.defineProperty(navigator, "serviceWorker", {
     }),
   },
   writable: true,
+  configurable: true,
 });
 
 // Mock console methods to keep test output clean

--- a/src/app/components/PwaComponents.tsx
+++ b/src/app/components/PwaComponents.tsx
@@ -3,7 +3,6 @@
 import { useEffect, useState } from "react";
 import {
   subscribeUser,
-  unsubscribeUser,
   type SerializablePushSubscription,
 } from "../actions";
 
@@ -210,18 +209,6 @@ export function PushNotificationManager() {
     }
   }
 
-  async function handleUnsubscribe() {
-    try {
-      if (subscription) {
-        const endpoint = subscription.endpoint;
-        await subscription.unsubscribe();
-        await unsubscribeUser(endpoint);
-        setSubscription(null);
-      }
-    } catch (error) {
-      console.error("Error unsubscribing from push notifications:", error);
-    }
-  }
 
   // Don't render during SSR
   if (!isMounted) {
@@ -233,21 +220,11 @@ export function PushNotificationManager() {
   }
 
   if (permission === "granted" && subscription) {
-    return (
+    return toast ? (
       <div className="fixed bottom-4 end-4 z-50">
-        <button
-          onClick={handleUnsubscribe}
-          className="bg-red-500 text-white px-4 py-2 rounded-md shadow-md hover:bg-red-600"
-        >
-          Disable Price Alerts
-        </button>
-        {toast && (
-          <div className="mt-2 bg-black text-white px-2 py-1 rounded">
-            {toast}
-          </div>
-        )}
+        <div className="mt-2 bg-black text-white px-2 py-1 rounded">{toast}</div>
       </div>
-    );
+    ) : null;
   }
 
   return (

--- a/test/client/PushNotificationManager.test.tsx
+++ b/test/client/PushNotificationManager.test.tsx
@@ -52,6 +52,7 @@ describe("PushNotificationManager", () => {
         requestPermission: jest.fn().mockResolvedValue("granted"),
       },
       writable: true,
+      configurable: true,
     });
 
     Object.defineProperty(navigator, "serviceWorker", {
@@ -69,6 +70,7 @@ describe("PushNotificationManager", () => {
         }),
       },
       writable: true,
+      configurable: true,
     });
 
     // Mock window.atob for base64 decoding
@@ -77,12 +79,14 @@ describe("PushNotificationManager", () => {
         return Buffer.from(str, "base64").toString("binary");
       }),
       writable: true,
+      configurable: true,
     });
 
     // Mock PushManager
     Object.defineProperty(window, "PushManager", {
       value: class MockPushManager {},
       writable: true,
+      configurable: true,
     });
   });
 
@@ -284,8 +288,7 @@ describe("PushNotificationManager", () => {
       });
     });
 
-    it("should successfully unsubscribe from push notifications", async () => {
-      // Set up existing subscription
+    it("should hide the button when already subscribed", async () => {
       Object.defineProperty(navigator, "serviceWorker", {
         value: {
           ready: Promise.resolve({
@@ -305,26 +308,14 @@ describe("PushNotificationManager", () => {
 
       render(<PushNotificationManager />);
 
-      // Wait for component to detect existing subscription
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: /disable price alerts/i })
-        ).toBeInTheDocument();
-      });
-
-      const button = screen.getByRole("button", {
-        name: /disable price alerts/i,
-      });
-      fireEvent.click(button);
-
-      await waitFor(() => {
-        expect(mockActions.unsubscribeUser).toHaveBeenCalledWith(
-          "https://fcm.googleapis.com/fcm/send/test-endpoint"
-        );
+          screen.queryByRole("button", { name: /disable price alerts/i })
+        ).not.toBeInTheDocument();
       });
     });
 
-    it("should handle unsubscription failure", async () => {
+    it("should not attempt to unsubscribe when no button is present", async () => {
       const mockUnsubscribe = jest.fn().mockResolvedValue(false);
       const mockSubscriptionWithFailure = {
         ...mockPushSubscription,
@@ -354,18 +345,11 @@ describe("PushNotificationManager", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: /disable price alerts/i })
-        ).toBeInTheDocument();
+          screen.queryByRole("button", { name: /disable price alerts/i })
+        ).not.toBeInTheDocument();
       });
 
-      const button = screen.getByRole("button", {
-        name: /disable price alerts/i,
-      });
-      fireEvent.click(button);
-
-      await waitFor(() => {
-        expect(mockUnsubscribe).toHaveBeenCalled();
-      });
+      expect(mockUnsubscribe).not.toHaveBeenCalled();
     });
   });
 
@@ -431,11 +415,11 @@ describe("PushNotificationManager", () => {
         expect(mockActions.subscribeUser).toHaveBeenCalled();
       });
 
-      // Component should still show the disable button even if sync fails
+      // Component should hide the button even if sync fails
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: /disable price alerts/i })
-        ).toBeInTheDocument();
+          screen.queryByRole("button", { name: /disable price alerts/i })
+        ).not.toBeInTheDocument();
       });
     });
   });
@@ -451,7 +435,7 @@ describe("PushNotificationManager", () => {
         ).toBeInTheDocument();
       });
 
-      // After enabling, should show disable button
+      // After enabling, button should be hidden
       Object.defineProperty(navigator, "serviceWorker", {
         value: {
           ready: Promise.resolve({
@@ -473,8 +457,8 @@ describe("PushNotificationManager", () => {
 
       await waitFor(() => {
         expect(
-          screen.getByRole("button", { name: /disable price alerts/i })
-        ).toBeInTheDocument();
+          screen.queryByRole("button", { name: /disable price alerts/i })
+        ).not.toBeInTheDocument();
       });
     });
 

--- a/test/client/TestNotification.test.tsx
+++ b/test/client/TestNotification.test.tsx
@@ -55,10 +55,11 @@ describe("TestNotification Component", () => {
     });
 
     it("should not render during SSR", () => {
-      const { container } = render(<TestNotification />);
+      const ReactDOMServer = require("react-dom/server.node");
 
-      // Initially should not render (SSR protection)
-      expect(container.firstChild).toBeNull();
+      const html = ReactDOMServer.renderToString(<TestNotification />);
+
+      expect(html).toBe("");
     });
   });
 

--- a/test/server/actions.test.ts
+++ b/test/server/actions.test.ts
@@ -66,13 +66,13 @@ describe("Notification Actions", () => {
   }
 
   beforeEach(async () => {
+    // Clear any existing subscriptions
+    await clearAllSubscriptions();
+
     jest.clearAllMocks();
     mockConsole.log.mockClear();
     mockConsole.error.mockClear();
     mockConsole.warn.mockClear();
-
-    // Clear any existing subscriptions
-    await clearAllSubscriptions();
 
     // Reset environment variables
     process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY = "test-vapid-public";


### PR DESCRIPTION
## Summary
- hide push notification button after enabling
- make jest setup mocks configurable
- adjust tests for new behavior and add SSR render test using server.node
- fix server actions tests by clearing subscriptions before clearing mocks

## Testing
- `pnpm test`
- `pnpm lint`


------
https://chatgpt.com/codex/tasks/task_e_683d537586a08328817497bf22240928

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Improved reliability of push notification and service worker mocks in tests by allowing properties to be reconfigured during testing.
	- Updated server-side rendering test for notifications to use a more accurate rendering method.

- **Refactor**
	- Simplified the push notification management UI by removing the "Disable Price Alerts" button and related unsubscribe functionality.
	- Adjusted tests to reflect the updated UI, focusing on the presence or absence of UI elements rather than button interactions.
	- Improved test setup order to ensure a clean state before running server-side tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->