### PR TITLE
Fix push alert UI and toast

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -35,6 +35,9 @@ const customJestConfig = {
       testEnvironment: "jest-environment-jsdom",
       testMatch: ["<rootDir>/test/client/**/*.test.{js,jsx,ts,tsx}"],
       setupFilesAfterEnv: ["<rootDir>/jest.setup.js"],
+      moduleNameMapper: {
+        "^@/(.*)$": "<rootDir>/src/$1",
+      },
       transform: {
         "^.+\\.(js|jsx|ts|tsx)$": ["babel-jest", { presets: ["next/babel"] }],
       },
@@ -43,6 +46,9 @@ const customJestConfig = {
       displayName: "server",
       testEnvironment: "jest-environment-node",
       testMatch: ["<rootDir>/test/server/**/*.test.{js,jsx,ts,tsx}"],
+      moduleNameMapper: {
+        "^@/(.*)$": "<rootDir>/src/$1",
+      },
       transform: {
         "^.+\\.(js|jsx|ts|tsx)$": ["babel-jest", { presets: ["next/babel"] }],
       },
@@ -51,6 +57,9 @@ const customJestConfig = {
       displayName: "integration",
       testEnvironment: "jest-environment-node",
       testMatch: ["<rootDir>/test/integration/**/*.test.{js,jsx,ts,tsx}"],
+      moduleNameMapper: {
+        "^@/(.*)$": "<rootDir>/src/$1",
+      },
       transform: {
         "^.+\\.(js|jsx|ts|tsx)$": ["babel-jest", { presets: ["next/babel"] }],
       },

--- a/src/app/components/BodyWrapper.tsx
+++ b/src/app/components/BodyWrapper.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import PwaClientWrapper from './PwaClientWrapper';
+import { Toaster } from '@/components/ui/toaster';
 
 interface BodyWrapperProps {
   children: React.ReactNode;
@@ -23,6 +24,7 @@ export default function BodyWrapper({ children }: BodyWrapperProps) {
         <>
           <PwaClientWrapper />
           {/* ServiceWorkerRegistration component already handles SW registration. */}
+          <Toaster />
         </>
       )}
     </>

--- a/src/app/components/PwaComponents.tsx
+++ b/src/app/components/PwaComponents.tsx
@@ -2,7 +2,6 @@
 
 import { useEffect, useState } from "react";
 import { toast } from "../../hooks/use-toast";
-import { Toaster } from "../../components/ui/toaster";
 import {
   subscribeUser,
   type SerializablePushSubscription,
@@ -215,7 +214,7 @@ export function PushNotificationManager() {
   }
 
   if (permission === "granted" && subscription) {
-    return <Toaster />;
+    return null;
   }
 
   return (
@@ -236,7 +235,6 @@ export function PushNotificationManager() {
           Enable Price Alerts
         </button>
       </div>
-      <Toaster />
     </>
   );
 }

--- a/src/app/components/PwaComponents.tsx
+++ b/src/app/components/PwaComponents.tsx
@@ -1,6 +1,8 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { toast } from "../../hooks/use-toast";
+import { Toaster } from "../../components/ui/toaster";
 import {
   subscribeUser,
   type SerializablePushSubscription,
@@ -118,7 +120,6 @@ export function PushNotificationManager() {
   );
   const [supported, setSupported] = useState(true);
   const [isMounted, setIsMounted] = useState(false);
-  const [toast, setToast] = useState("");
 
   useEffect(() => {
     setIsMounted(true);
@@ -185,8 +186,7 @@ export function PushNotificationManager() {
       const vapidPublicKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
 
       if (!vapidPublicKey) {
-        setToast("VAPID key missing");
-        setTimeout(() => setToast(""), 3000);
+        toast({ description: "VAPID key missing" });
         return;
       }
 
@@ -202,8 +202,7 @@ export function PushNotificationManager() {
       // Send serialized subscription to server
       await subscribeUser(serializeSubscription(newSubscription));
 
-      setToast("Price alerts enabled");
-      setTimeout(() => setToast(""), 3000);
+      toast({ description: "Price alerts enabled" });
     } catch (error) {
       console.error("Error subscribing to push notifications:", error);
     }
@@ -211,44 +210,34 @@ export function PushNotificationManager() {
 
 
   // Don't render during SSR
-  if (!isMounted) {
-    return null;
-  }
-
-  if (!supported) {
+  if (!isMounted || !supported) {
     return null;
   }
 
   if (permission === "granted" && subscription) {
-    return toast ? (
-      <div className="fixed bottom-4 end-4 z-50">
-        <div className="mt-2 bg-black text-white px-2 py-1 rounded">{toast}</div>
-      </div>
-    ) : null;
+    return <Toaster />;
   }
 
   return (
-    <div className="fixed bottom-4 end-4 z-50">
-      <button
-        onClick={handleRequestPermission}
-        disabled={permission === "denied"}
-        title={
-          permission === "denied"
-            ? "Notifications blocked – enable in browser settings."
-            : undefined
-        }
-        className={`bg-yellow-500 text-white px-4 py-2 rounded-md shadow-md hover:bg-yellow-600 ${
-          permission === "denied" ? "opacity-50 cursor-not-allowed" : ""
-        }`}
-      >
-        Enable Price Alerts
-      </button>
-      {toast && (
-        <div className="mt-2 bg-black text-white px-2 py-1 rounded">
-          {toast}
-        </div>
-      )}
-    </div>
+    <>
+      <div className="fixed bottom-4 end-4 z-50">
+        <button
+          onClick={handleRequestPermission}
+          disabled={permission === "denied"}
+          title={
+            permission === "denied"
+              ? "Notifications blocked – enable in browser settings."
+              : undefined
+          }
+          className={`bg-yellow-500 text-white px-4 py-2 rounded-md shadow-md hover:bg-yellow-600 ${
+            permission === "denied" ? "opacity-50 cursor-not-allowed" : ""
+          }`}
+        >
+          Enable Price Alerts
+        </button>
+      </div>
+      <Toaster />
+    </>
   );
 }
 

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -5,7 +5,7 @@ import * as ToastPrimitives from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
 
-import { cn } from "@/lib/utils"
+import { cn } from "../../lib/utils"
 
 const ToastProvider = ToastPrimitives.Provider
 

--- a/src/components/ui/toast.tsx
+++ b/src/components/ui/toast.tsx
@@ -5,7 +5,7 @@ import * as ToastPrimitives from "@radix-ui/react-toast"
 import { cva, type VariantProps } from "class-variance-authority"
 import { X } from "lucide-react"
 
-import { cn } from "../../lib/utils"
+import { cn } from "@/lib/utils"
 
 const ToastProvider = ToastPrimitives.Provider
 

--- a/src/components/ui/toaster.tsx
+++ b/src/components/ui/toaster.tsx
@@ -1,6 +1,6 @@
 "use client"
 
-import { useToast } from "@/hooks/use-toast"
+import { useToast } from "../../hooks/use-toast"
 import {
   Toast,
   ToastClose,
@@ -8,7 +8,7 @@ import {
   ToastProvider,
   ToastTitle,
   ToastViewport,
-} from "@/components/ui/toast"
+} from "./toast"
 
 export function Toaster() {
   const { toasts } = useToast()

--- a/test/client/PushNotificationManager.test.tsx
+++ b/test/client/PushNotificationManager.test.tsx
@@ -2,6 +2,7 @@ import React from "react";
 import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { PushNotificationManager } from "../../src/app/components/PwaComponents";
+import { Toaster } from "../../src/components/ui/toaster";
 import * as actions from "../../src/app/actions";
 
 // Mock the actions module
@@ -37,6 +38,12 @@ function urlBase64ToUint8Array(base64String: string) {
     outputArray[i] = rawData.charCodeAt(i);
   }
   return outputArray;
+}
+
+function renderManager() {
+  const utils = render(<PushNotificationManager />);
+  render(<Toaster />);
+  return utils;
 }
 
 describe("PushNotificationManager", () => {
@@ -95,28 +102,28 @@ describe("PushNotificationManager", () => {
       // Mock missing Notification API
       delete (window as any).Notification;
 
-      const { container } = render(<PushNotificationManager />);
+      const { container } = renderManager();
       expect(container.firstChild).toBeNull();
     });
 
     it("should not render when service workers are not supported", () => {
       delete (navigator as any).serviceWorker;
 
-      const { container } = render(<PushNotificationManager />);
+      const { container } = renderManager();
       expect(container.firstChild).toBeNull();
     });
 
     it("should not render when push manager is not supported", () => {
       delete (window as any).PushManager;
 
-      const { container } = render(<PushNotificationManager />);
+      const { container } = renderManager();
       expect(container.firstChild).toBeNull();
     });
   });
 
   describe("Initial State", () => {
     it("should render enable button when permission is default", async () => {
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         expect(
@@ -131,7 +138,7 @@ describe("PushNotificationManager", () => {
         writable: true,
       });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         const button = screen.getByRole("button", {
@@ -156,7 +163,7 @@ describe("PushNotificationManager", () => {
 
       mockActions.subscribeUser.mockResolvedValue({ success: true });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         const button = screen.getByRole("button", {
@@ -177,7 +184,7 @@ describe("PushNotificationManager", () => {
         writable: true,
       });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         const button = screen.getByRole("button", {
@@ -206,7 +213,7 @@ describe("PushNotificationManager", () => {
     it("should successfully subscribe to push notifications", async () => {
       mockActions.subscribeUser.mockResolvedValue({ success: true });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         const button = screen.getByRole("button", {
@@ -243,7 +250,7 @@ describe("PushNotificationManager", () => {
         writable: true,
       });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         const button = screen.getByRole("button", {
@@ -265,7 +272,7 @@ describe("PushNotificationManager", () => {
         success: false,
       });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         const button = screen.getByRole("button", {
@@ -306,7 +313,7 @@ describe("PushNotificationManager", () => {
       mockActions.subscribeUser.mockResolvedValue({ success: true });
       mockActions.unsubscribeUser.mockResolvedValue({ success: true });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         expect(
@@ -341,7 +348,7 @@ describe("PushNotificationManager", () => {
       mockActions.subscribeUser.mockResolvedValue({ success: true });
       mockActions.unsubscribeUser.mockResolvedValue({ success: true });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         expect(
@@ -375,7 +382,7 @@ describe("PushNotificationManager", () => {
 
       mockActions.subscribeUser.mockResolvedValue({ success: true });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         expect(mockActions.subscribeUser).toHaveBeenCalledWith({
@@ -409,7 +416,7 @@ describe("PushNotificationManager", () => {
 
       mockActions.subscribeUser.mockRejectedValue(new Error("Sync failed"));
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         expect(mockActions.subscribeUser).toHaveBeenCalled();
@@ -426,7 +433,7 @@ describe("PushNotificationManager", () => {
 
   describe("UI State Management", () => {
     it("should show correct button text based on subscription state", async () => {
-      render(<PushNotificationManager />);
+      renderManager();
 
       // Initially should show enable button
       await waitFor(() => {
@@ -467,7 +474,7 @@ describe("PushNotificationManager", () => {
       const originalVapidKey = process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
       delete process.env.NEXT_PUBLIC_VAPID_PUBLIC_KEY;
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         const button = screen.getByRole("button", {
@@ -494,7 +501,7 @@ describe("PushNotificationManager", () => {
         writable: true,
       });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         const button = screen.getByRole("button", {
@@ -518,7 +525,7 @@ describe("PushNotificationManager", () => {
         writable: true,
       });
 
-      render(<PushNotificationManager />);
+      renderManager();
 
       await waitFor(() => {
         const button = screen.getByRole("button", {


### PR DESCRIPTION
## Summary
- hide enable button after subscription
- show toast with shadcn component
- add Toaster wrapper so toasts render

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_683d5785e174832887c5e902d8b7eaa1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Centralized toast notifications are now used for push notification actions, providing more consistent and visible feedback to users.
- **Improvements**
  - Toast notifications are now displayed via a unified system across the app, streamlining the notification experience.
- **Bug Fixes**
  - Improved reliability of notification permission prompts and error messages.
- **Tests**
  - Updated tests to ensure toast notifications are properly rendered and verified during push notification flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->